### PR TITLE
Wrap view_image

### DIFF
--- a/cpp-scripts/view_image_function.hpp
+++ b/cpp-scripts/view_image_function.hpp
@@ -1,0 +1,55 @@
+/* Copyright (C) 2020 Pablo Hernandez-Cerdan
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef VIEW_IMAGE_FUNCTION_HPP
+#define VIEW_IMAGE_FUNCTION_HPP
+
+#include <string>
+#include "itkImage.h"
+#include "itkImageFileReader.h"
+#include "itkViewImage.h"
+
+namespace SG {
+    namespace defaults {
+        const std::string view_image_win_title = "SGEXT itkViewImage";
+        const size_t view_image_win_width = 600;
+        const size_t view_image_win_height = 600;
+    }
+
+template<typename ImageType>
+void view_image(const std::string & inputFile,
+        const std::string & winTitle = defaults::view_image_win_title,
+        const size_t & winWidth = defaults::view_image_win_width,
+        const size_t & winHeight = defaults::view_image_win_width)
+{
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  auto reader = ReaderType::New();
+  reader->SetFileName(inputFile);
+  reader->Update();
+
+  itk::ViewImage<ImageType>::View(reader->GetOutput(), winTitle, winWidth, winHeight);
+}
+
+template<typename ImageType>
+void view_image(const ImageType* img_ptr,
+        const std::string & winTitle = defaults::view_image_win_title,
+        const size_t & winWidth = defaults::view_image_win_width,
+        const size_t & winHeight = defaults::view_image_win_height)
+{
+  itk::ViewImage<ImageType>::View(img_ptr, winTitle, winWidth, winHeight);
+}
+
+template<typename ImageType>
+void view_image(const typename ImageType::Pointer & img_smart_ptr,
+        const std::string & winTitle = defaults::view_image_win_title,
+        const size_t & winWidth = defaults::view_image_win_width,
+        const size_t & winHeight = defaults::view_image_win_height)
+{
+    return view_image(img_smart_ptr.GetPointer(),
+            winTitle, winWidth, winHeight);
+}
+
+} // end ns
+#endif

--- a/wrap/itk/CMakeLists.txt
+++ b/wrap/itk/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(current_sources_
   sgitk_init_py.cpp
   itk_image_py.cpp
+  itk_view_image_py.cpp
   )
 set(module_name_ ${CMAKE_CURRENT_SOURCE_DIR})
 list(TRANSFORM current_sources_ PREPEND "${module_name_}/")

--- a/wrap/itk/declare_itk_view_image_py.h
+++ b/wrap/itk/declare_itk_view_image_py.h
@@ -1,0 +1,35 @@
+/* Copyright (C) 2020 Pablo Hernandez-Cerdan
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef DECLARE_ITK_VIEW_IMAGE_PY_H
+#define DECLARE_ITK_VIEW_IMAGE_PY_H
+
+#include <pybind11/pybind11.h>
+
+#include "view_image_function.hpp"
+
+/** For now make copies of data to numpy arrays.
+ * Some examples (pybind11 source code docs are non-existant)
+ * From: https://github.com/pybind/pybind11/issues/323
+ * Also: https://github.com/pybind/pybind11/issues/1042
+ * dtypes: https://docs.scipy.org/doc/numpy/user/basics.types.html
+ * py::dtype::of<TIMG::ObjectType::PixelType>(),
+ */
+template<typename TImage>
+void declare_itk_view_image(pybind11::module &m, const std::string &typestr) {
+    namespace py = pybind11;
+    const std::string help_str =
+        "Visualize image from input image of type: " + typestr + ".";
+    m.def("view_image",
+            py::overload_cast< const typename TImage::Pointer &, const std::string&,
+                const size_t&, const size_t&>(&SG::view_image<TImage>),
+            help_str.c_str(),
+            py::arg("input"),
+            py::arg("win_title") = SG::defaults::view_image_win_title,
+            py::arg("win_width") = SG::defaults::view_image_win_width,
+            py::arg("win_height") = SG::defaults::view_image_win_height
+         );
+}
+#endif

--- a/wrap/itk/itk_image_py.cpp
+++ b/wrap/itk/itk_image_py.cpp
@@ -6,14 +6,12 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 
+#include "sgitk_common_py.hpp"
 #include "declare_itk_image_py.h"
 
 namespace py = pybind11;
 
-using IUC3P = itk::Image<unsigned char, 3>::Pointer;
-using IF3P = itk::Image<float, 3>::Pointer;
 void init_itk_image(py::module &m) {
-    declare_itk_image_ptr<IUC3P>(m, "IUC3P");
-    declare_itk_image_ptr<IF3P>(m, "IF3P");
-
+    declare_itk_image_ptr<SG::IUC3P>(m, "IUC3P");
+    declare_itk_image_ptr<SG::IF3P>(m, "IF3P");
 }

--- a/wrap/itk/itk_view_image_py.cpp
+++ b/wrap/itk/itk_view_image_py.cpp
@@ -1,0 +1,29 @@
+/* Copyright (C) 2020 Pablo Hernandez-Cerdan
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <pybind11/pybind11.h>
+#include "sgitk_common_py.hpp"
+#include "view_image_function.hpp"
+#include "declare_itk_view_image_py.h"
+
+namespace py = pybind11;
+
+void init_itk_view_image(py::module &m) {
+    using TImageFromFile = SG::IF3;
+    m.def("view_image",
+            py::overload_cast< const std::string&, const std::string&,
+                const size_t&, const size_t&>(&SG::view_image<TImageFromFile>),
+            "Visualize image from file.\n"
+            "To maximize usability among all types of images, "
+            "it treats the input image as having float pixels.",
+            py::arg("input_file"),
+            py::arg("win_title") = SG::defaults::view_image_win_title,
+            py::arg("win_width") = SG::defaults::view_image_win_width,
+            py::arg("win_height") = SG::defaults::view_image_win_height
+         );
+
+    declare_itk_view_image<SG::IF3>(m, "float (IF3)");
+    declare_itk_view_image<SG::IUC3>(m, "unsigned char (IUC3)");
+}

--- a/wrap/itk/sgitk_common_py.hpp
+++ b/wrap/itk/sgitk_common_py.hpp
@@ -6,4 +6,13 @@
 #ifndef SGITK_COMMON_PYBIND_HPP
 #define SGITK_COMMON_PYBIND_HPP
 
+#include <itkImage.h>
+
+namespace SG {
+using IUC3 = itk::Image<unsigned char, 3>;
+using IUC3P = typename IUC3::Pointer;
+using IF3 = itk::Image<float, 3>;
+using IF3P = typename IF3::Pointer;
+}
+
 #endif

--- a/wrap/itk/sgitk_init_py.cpp
+++ b/wrap/itk/sgitk_init_py.cpp
@@ -7,9 +7,11 @@
 
 namespace py = pybind11;
 void init_itk_image(py::module &);
+void init_itk_view_image(py::module &);
 
 void init_sgitk(py::module & mparent) {
     auto m = mparent.def_submodule("itk");
     m.doc() = "ITK wrapping of image "; // optional module docstring
     init_itk_image(m);
+    init_itk_view_image(m);
 }

--- a/wrap/test/itk/CMakeLists.txt
+++ b/wrap/test/itk/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(python_tests_
   test_itk_image.py
+  test_itk_view_image.py # Creates windows that have to be manually closed
   )
 
 get_filename_component(module_name_ ${CMAKE_CURRENT_SOURCE_DIR} NAME)

--- a/wrap/test/itk/test_itk_image.py
+++ b/wrap/test/itk/test_itk_image.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2019 Pablo Hernandez-Cerdan
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import _sgext.itk as itk
 import _sgext.scripts as scripts
 import unittest

--- a/wrap/test/itk/test_itk_view_image.py
+++ b/wrap/test/itk/test_itk_view_image.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2019 Pablo Hernandez-Cerdan
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import _sgext.itk as itk
+import _sgext.scripts as scripts
+import unittest
+import os, tempfile
+
+class TestITKViewImage(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Create temp directory
+        cls.test_dir = tempfile.mkdtemp()
+        dirname = os.path.dirname(os.path.abspath(__file__))
+        cls.input = os.path.join(dirname, '../../../images/bX3D.tif')
+        if not os.path.exists(cls.input):
+            raise "Input image for script used in test_view_image not found: " + cls.input
+        cls.img =scripts.create_distance_map_io(input_file=cls.input,
+                          out_folder=cls.test_dir,
+                          foreground="black",
+                          verbose=True)
+
+    # TODO closing is not automated
+    def test_from_file(self):
+        itk.view_image(input_file=self.input, win_title = "Original image (foreground=black)")
+
+    def test_from_sgext_itk_img(self):
+        itk.view_image(input=self.img, win_title = "DMap")
+


### PR DESCRIPTION
Needs ITK to be compiled with ITKVtkGlue module to access to `itk::ViewImage`

```python
import sgext
sgext.itk.view_image(input_file="./path")
sgext.itk.view_image(input=an_sgext_itk_img)
```

Accepts different types of sgext_itk_img
For now: UC3 and F3 (unsigned char and float)