### PR TITLE
Add azure-pipelines for the dependencies sub-project

### DIFF
--- a/dependencies/azure-pipelines.yml
+++ b/dependencies/azure-pipelines.yml
@@ -1,0 +1,78 @@
+# https://aka.ms/yaml
+
+stages:
+- stage: 'DeployLinux'
+  dependsOn: []
+  pool:
+    vmImage: 'ubuntu-18.04'
+  variables:
+    DEPENDENCIES_BUILD_DIR: $(Agent.BuildDirectory)/build_deps
+  jobs:
+  - job: build_dependencies_linux
+    displayName: 'BuildDependencies'
+    timeoutInMinutes: 0
+    steps:
+    - script: |
+        mkdir $DEPENDENCIES_BUILD_DIR
+        echo $DEPENDENCIES_BUILD_DIR
+      displayName: "mkdir DEPENDENCIES_BUILD_DIR"
+    - task: Bash@3
+      inputs:
+        filePath: '$(Build.SourcesDirectory)/deploy/deploy_dependencies.sh'
+        workingDirectory: '$(Build.SourcesDirectory)'
+      displayName: 'Build dependencies'
+    - publish: $(DEPENDENCIES_BUILD_DIR)
+      artifact: DEPENDENCIES_BUILD_DIR_LINUX
+
+- stage: 'DeployMacOS'
+  dependsOn: []
+  pool:
+    vmImage: 'macOS-10.15'
+  variables:
+    DEPENDENCIES_BUILD_DIR: $(Agent.BuildDirectory)/build_deps
+  jobs:
+  - job: build_dependencies_macos
+    displayName: 'BuildDependencies'
+    timeoutInMinutes: 0
+    steps:
+    - script: |
+        mkdir $DEPENDENCIES_BUILD_DIR
+        echo $DEPENDENCIES_BUILD_DIR
+      displayName: "mkdir DEPENDENCIES_BUILD_DIR"
+    - task: Bash@3
+      inputs:
+        filePath: '$(Build.SourcesDirectory)/deploy/deploy_dependencies.sh'
+        workingDirectory: '$(Build.SourcesDirectory)'
+      displayName: 'Build dependencies'
+    - publish: $(DEPENDENCIES_BUILD_DIR)
+      artifact: DEPENDENCIES_BUILD_DIR_MACOS
+
+- stage: 'DeployWindows'
+  dependsOn: []
+  pool:
+    vmImage: 'windows-2019'
+  variables:
+    DEPENDENCIES_BUILD_DIR: $(Agent.BuildDirectory)/build_deps
+  jobs:
+  - job: build_dependencies_win
+    displayName: 'BuildDependencies'
+    timeoutInMinutes: 0
+    steps:
+    - task: Bash@3
+      inputs:
+        targetType: 'inline'
+        script: |
+          mkdir $DEPENDENCIES_BUILD_DIR
+          echo $DEPENDENCIES_BUILD_DIR
+      displayName: "mkdir DEPENDENCIES_BUILD_DIR"
+    - script: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        cd $(DEPENDENCIES_BUILD_DIR)
+        cmake $(Build.SourcesDirectory)\dependencies -G Ninja -DCMAKE_C_COMPILER:FILEPATH="cl.exe" -DCMAKE_CXX_COMPILER:FILEPATH="cl.exe" -DCMAKE_BUILD_TYPE=Release -DWITH_TBB:BOOL=OFF -DWITH_VTK:BOOL=ON -DWITH_ITK:BOOL=ON -DBoost_USE_STATIC_LIBS:BOOL=ON
+        cmake --build .
+        cmake --build . --target clean_artifacts
+      workingDirectory: $(Agent.BuildDirectory)
+      displayName: 'Build dependencies'
+
+    - publish: $(DEPENDENCIES_BUILD_DIR)
+      artifact: DEPENDENCIES_BUILD_DIR_WIN

--- a/dependencies/azure-pipelines.yml
+++ b/dependencies/azure-pipelines.yml
@@ -16,6 +16,8 @@ stages:
         mkdir $DEPENDENCIES_BUILD_DIR
         echo $DEPENDENCIES_BUILD_DIR
       displayName: "mkdir DEPENDENCIES_BUILD_DIR"
+    - script: sudo apt-get -y install libxt-dev libgl1-mesa-dev
+      displayName: "install libXt and opengl dependencies"
     - task: Bash@3
       inputs:
         filePath: '$(Build.SourcesDirectory)/deploy/deploy_dependencies.sh'

--- a/deploy/deploy_dependencies.sh
+++ b/deploy/deploy_dependencies.sh
@@ -2,11 +2,17 @@
 
 script_dir=$(cd $(dirname $0) || exit 1; pwd)
 dependencies_src_dir=$script_dir/../dependencies
+echo dependencies_src_dir: $dependencies_src_dir
 
 # REQUIRES existing DEPENDENCIES_BUILD_DIR
 # Requires CMake and Ninja
+python -m pip install --upgrade pip
 python -m pip install cmake
 python -m pip install ninja
+if [[ $OSTYPE == linux* ]]; then
+  export PATH="$PATH:/home/vsts/.local/bin"
+fi
+echo ninja version: $(ninja --version)
 
 if [ ! -d "$DEPENDENCIES_BUILD_DIR" ]; then
   echo ERROR: DEPENDENCIES_BUILD_DIR does not exist: $DEPENDENCIES_BUILD_DIR
@@ -18,13 +24,6 @@ echo OSTYPE: $OSTYPE
 export CMAKE_EXECUTABLE=cmake
 export SGEXT_BUILD_TYPE=Release
 export CMAKE_GENERATOR=Ninja
-
-# linux (default)
-export CMAKE_OS_VARIABLES='\
-  -DCMAKE_CXX_STANDARD=14 \
-  -DCMAKE_C_COMPILER:PATH=gcc \
-  -DCMAKE_CXX_COMPILER:PATH=g++ \
-  '
 
 # macos:
 if [[ $OSTYPE == darwin* ]]; then


### PR DESCRIPTION
This will allow to only build dependencies once (nightly),
and the project will download the built depedencies.

This will shorten the time of building the project 40-50 min.

The triggers of `dependencies/azure-pipelines.yml` is managed
from the UI of azure, not form the `yml`.
It is disabled for CI and PR, but scheduled to run every night at
`5am (GMT+1)`.