### PR TITLE
Update DGtal to use DGtalLUT

### DIFF
--- a/cpp-scripts/thin_function.cpp
+++ b/cpp-scripts/thin_function.cpp
@@ -22,7 +22,7 @@
 #include <DGtal/topology/VoxelComplexFunctions.h>
 
 #include <DGtal/topology/NeighborhoodConfigurations.h>
-#include <DGtal/topology/tables/NeighborhoodTables.h>
+#include <DGtal/topology/tables/NeighborhoodLUT.h>
 
 // Iterate for sequence discrete points
 #include <itkIndexRange.h>
@@ -112,16 +112,16 @@ BinaryImageType::Pointer thin_function(
 
     vc.construct(image_set);
   }
-  vc.setSimplicityTable(DGtal::functions::loadTable(DGtal::simplicity::tableSimple26_6));
+  vc.setSimplicityTable(DGtal::simplicity::LUTSimple26_6);
   if(verbose) DGtal::trace.endBlock();
 
   if(verbose) DGtal::trace.beginBlock("load isthmus table");
   boost::dynamic_bitset<> isthmus_table;
   auto &sk = skel_type;
   if(sk == SkelType::isthmus)
-    isthmus_table = *DGtal::functions::loadTable(DGtal::isthmusicity::tableIsthmus);
+    isthmus_table = *DGtal::isthmusicity::LUTIsthmus;
   else if(sk == SkelType::isthmus1)
-    isthmus_table = *DGtal::functions::loadTable(DGtal::isthmusicity::tableOneIsthmus);
+    isthmus_table = *DGtal::isthmusicity::LUTOneIsthmus;
   if(verbose) DGtal::trace.endBlock();
 
 

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -225,12 +225,13 @@ endif()
 #################### DGtal #######################
 ##################################################
 
-set(DGtal_GIT_TAG 92ab4d0d62f0e5490f1890efdf904547d17515b9) # 25-May-2020
+# set(DGtal_GIT_TAG 92ab4d0d62f0e5490f1890efdf904547d17515b9) # 25-May-2020
+set(DGtal_GIT_TAG add_dgtal_lut) # 26-May-2020
 message(STATUS "DGtal_VERSION: ${DGtal_GIT_TAG}")
 set(DGtal_BUILD_DIR ${OUTPUT_BUILD_DIR}/DGtal-build)
 set(DGtal_SRC_FOLDER_NAME DGtal-src)
 set(DGtal_SRC_DIR ${OUTPUT_BUILD_DIR}/${DGtal_SRC_FOLDER_NAME})
-set(DGtal_GIT_REPOSITORY "https://github.com/DGtal-team/DGtal")
+set(DGtal_GIT_REPOSITORY "https://github.com/phcerdan/DGtal")
 set(_DGtal_depends ep_boost)
 set(_DGtal_optional_cmake_args)
 if(WITH_ITK)
@@ -273,6 +274,7 @@ ExternalProject_Add(ep_dgtal
       -DBUILD_SHARED_LIBS:BOOL=OFF
       -DBUILD_TESTING:BOOL=OFF
       -DBUILD_EXAMPLES:BOOL=OFF
+      -DWITH_DGtalLUT:BOOL=ON
       -DCMAKE_FIND_PACKAGE_PREFER_CONFIG:BOOL=ON
       -DBoost_DIR=${BOOST_BUILD_DIR}/lib/cmake/Boost-${BOOST_VERSION_DOTS}
       ${_DGtal_optional_cmake_args}

--- a/dependencies/docker/Dockerfile-dockcross-manylinux2014-base
+++ b/dependencies/docker/Dockerfile-dockcross-manylinux2014-base
@@ -76,13 +76,13 @@ RUN wget "https://dl.bintray.com/boostorg/release/${BOOST_VERSION_DOTS}/source/b
 
 ############# DGtal #############
 # Install DGtal from git
-ENV DGtal_GIT_TAG 71140534477a3dd41ff8311b9176c76a52ec0b97
+ENV DGtal_GIT_TAG add_dgtal_lut
 ENV DGtal_BUILD_DIR ${BUILD_PATH}/DGtal-build
 ENV DGtal_SRC_FOLDER_NAME DGtal-src
 ENV DGtal_SRC_DIR ${BUILD_PATH}/${DGtal_SRC_FOLDER_NAME}
 
 WORKDIR $BUILD_PATH
-RUN git clone --single-branch https://github.com/DGtal-team/DGtal.git ${DGtal_SRC_FOLDER_NAME} && \
+RUN git clone https://github.com/phcerdan/DGtal.git ${DGtal_SRC_FOLDER_NAME} && \
     cd $DGtal_SRC_DIR && \
     git checkout ${DGtal_GIT_TAG} && \
     mkdir ${DGtal_BUILD_DIR} && cd ${DGtal_BUILD_DIR} && \
@@ -92,6 +92,7 @@ RUN git clone --single-branch https://github.com/DGtal-team/DGtal.git ${DGtal_SR
         -DBUILD_SHARED_LIBS:BOOL=ON \
         -DBUILD_TESTING:BOOL=OFF \
         -DBUILD_EXAMPLES:BOOL=OFF \
+        -DWITH_DGtalLUT:BOOL=ON \
         # TODO: Switch these two ON when CMake is at least 3.15 and remove Boost_ROOT
         # -DCMAKE_FIND_PACKAGE_PREFER_CONFIG:BOOL=ON \
         # -DBoost_DIR:STRING=${BOOST_CMAKE_CONFIG_FOLDER} \


### PR DESCRIPTION
DGtal PR: https://github.com/DGtal-team/DGtal/pull/1496
phcerdan branch: add_dgtal_lut

This fixes the problem with `loadTable(table_filepath)` that arise in python.
`table_filepath` is fixed to build or install tree, and does not allow
re-alocation of the libraries. Basically is impossible to use
`DGtal::functions::loadTable` without development files.