### PR TITLE
CMake: Improve infrastucture for external modules.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,15 @@ if(SG_WRAP_PYTHON)
     FetchContent_Populate(pybind11)
     add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
   endif()
+  # Export pybind to the build tree to facilitate external modules to reuse it
+  # But not to the install tree.
+  # External modules can link to SGEXT::pybind11 or SGEXT::module (only from the build tree)
+  # And then:
+  # include(${SGEXT_DIR}/_deps/pybind11-src/tools/pybind11Tools.cmake)
+  # to access the same pybind11_add_module CMake function.
+  export(TARGETS pybind11 module
+    NAMESPACE SGEXT::
+    APPEND FILE ${sgext_export_file})
 endif()
 
 set(SG_LIBRARIES)
@@ -324,3 +333,13 @@ if(SG_WRAP_PYTHON)
   add_dependencies(sgext-install-runtime _sgext)
 endif()
 
+# Copy to the build tree the cmake modules (to allow reuse from SGEXT_DIR after a find_package)
+file(COPY
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/SGEXT_SGModuleMacros.cmake
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/SGEXT_handle_dependencies.cmake
+ DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/cmake)
+
+install(FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/SGEXT_SGModuleMacros.cmake
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/SGEXT_handle_dependencies.cmake
+  DESTINATION ${install_cmake_dir} )

--- a/test/mock_project/CMakeLists.txt
+++ b/test/mock_project/CMakeLists.txt
@@ -4,6 +4,33 @@ project(mock_project_using_SGEXT)
 # You will still need to provide all the SGEXT dependencies:
 # -DGtal_DIR=/path -DITK_DIR=/path -DVTK_DIR and -DBoost_DIR
 find_package(SGEXT CONFIG REQUIRED)
+
 add_executable(mock_main mock_main.cpp)
 target_link_libraries(mock_main SGEXT::SGAnalyze)
+option(SGEXT_WITH_WRAP "SGEXT was compiled with python wrappings and this projects want to reuse them" OFF)
+if(SGEXT_WITH_WRAP)
+  # Pybind11 does not link to Python in Linux and MacOS
+  find_package(Python COMPONENTS REQUIRED Interpreter Development)
+  target_link_libraries(mock_main SGEXT::_sgext)
+  target_link_libraries(mock_main Python::Python)
+  target_compile_definitions(mock_main PUBLIC SGEXT_WITH_WRAP)
+
+  # Add pybind11 module (it's a library)
+  # Inlude the macro pybind11_add_module (needs SGEXT from a build tree)
+
+  list(APPEND CMAKE_MODULE_PATH "${SGEXT_DIR}/_deps/pybind11-src/tools")
+  include(${SGEXT_DIR}/_deps/pybind11-src/tools/pybind11Tools.cmake)
+  pybind11_add_module(_mock
+    SHARED
+    mock_module_py.cpp # Where module is added
+    ${all_modules_python_sources} # all the collected sources in submodules
+    )
+  add_library(SGEXT::_mock ALIAS _mock)
+  # To access headers related with pybind11 defined in sgext, i.e locate/sglocateo_common.h, or pybind11_common.h
+  target_link_libraries(_mock PUBLIC SGEXT::_sgext)
+  # To access pybind11 headers (might not be needed)
+  # target_link_libraries(_mock PRIVATE SGEXT::pybind11)
+  # We need to link to python
+  target_link_libraries(_mock PRIVATE Python::Python)
+endif()
 

--- a/test/mock_project/mock_main.cpp
+++ b/test/mock_project/mock_main.cpp
@@ -7,6 +7,10 @@
 #include "spatial_graph.hpp"
 #include "compute_graph_properties.hpp"
 
+#ifdef SGEXT_WITH_WRAP
+#include "locate/sglocate_common.h"
+#endif
+
 int main() {
   SG::GraphType g(2);
   SG::compute_degrees(g);

--- a/test/mock_project/mock_module_py.cpp
+++ b/test/mock_project/mock_module_py.cpp
@@ -1,0 +1,18 @@
+/* Copyright (C) 2020 Pablo Hernandez-Cerdan
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "pybind11_common.h"
+namespace py = pybind11;
+
+void init_sgmock(py::module &);
+PYBIND11_MODULE(_mock, m) {
+    m.doc() = "Mock external module for SGEXT";
+    init_sgmock(m);
+}
+
+void init_sgmock(py::module &m) {
+    m.def("say_mock", [](){std::cout <<"Mock!" << std::endl;});
+}
+

--- a/wrap/CMakeLists.txt
+++ b/wrap/CMakeLists.txt
@@ -1,4 +1,6 @@
 # Python wrapping will be one single module with submodules
+set(CMAKE_INSTALL_PYTHONINCLUDEDIR
+  ${CMAKE_INSTALL_PYTHONLIBDIR}/include)
 set(enabled_libs_ SGCore)
 set(enabled_include_dirs_)
 set(enabled_include_system_dirs_)
@@ -37,6 +39,9 @@ if(SG_MODULE_SCRIPTS)
   add_subdirectory(itk)
 endif()
 
+set(wrap_header_common
+  pybind11_common.h)
+
 # Add the pybind module
 # Use SHARED instead of the deault MODULE to allow external plugins to link to it.
 # This would require the same CI/CD to build and link these external plugins.
@@ -47,8 +52,13 @@ pybind11_add_module(_sgext
   )
 add_library(SGEXT::_sgext ALIAS _sgext)
 target_link_libraries(_sgext PRIVATE ${enabled_libs_})
-target_include_directories(_sgext PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}) # For pybind11_common.h
-target_include_directories(_sgext PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/submodules) # For #include "locate/sglocate_common.h"
+target_include_directories(_sgext PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_PYTHONINCLUDEDIR}>
+  ) # For pybind11_common.h
+target_include_directories(_sgext PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/submodules>
+  ) # For #include "locate/sglocate_common.h"
 target_include_directories(_sgext PRIVATE ${enabled_include_dirs_})
 target_include_directories(_sgext SYSTEM PRIVATE ${enabled_include_system_dirs_})
 if(SG_REQUIRES_VTK)
@@ -79,10 +89,10 @@ if(SG_MODULE_SCRIPTS)
   target_compile_definitions(_sgext PRIVATE SG_MODULE_SCRIPTS_ENABLED)
 endif()
 
-install(TARGETS _sgext
-  DESTINATION ${CMAKE_INSTALL_PYTHONLIBDIR}
-  COMPONENT runtime
-  )
+install(FILES ${wrap_header_common}
+  DESTINATION ${CMAKE_INSTALL_PYTHONINCLUDEDIR}
+  COMPONENT development)
+
 install(FILES __init__.py
   DESTINATION ${CMAKE_INSTALL_PYTHONLIBDIR}
   COMPONENT runtime
@@ -111,6 +121,18 @@ install(DIRECTORY ${table_folder}
   DESTINATION ${CMAKE_INSTALL_PYTHONLIBDIR}
   COMPONENT runtime
   )
+
+# Export _sgext to let external plugins link to SGEXT::_sgext
+# export to install tree: (always to CMAKE_INSTALL_PYTHONLIBDIR)
+install(TARGETS _sgext
+  EXPORT SGEXTTargets
+  RUNTIME DESTINATION ${CMAKE_INSTALL_PYTHONLIBDIR} COMPONENT runtime
+  LIBRARY DESTINATION ${CMAKE_INSTALL_PYTHONLIBDIR} COMPONENT runtime
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_PYTHONLIBDIR} COMPONENT development)
+# export _sgext to the build tree
+export(TARGETS _sgext
+  NAMESPACE SGEXT::
+  APPEND FILE ${sgext_export_file})
 
 if(SG_BUILD_TESTING)
   add_subdirectory(test)

--- a/wrap/submodules/dynamics/CMakeLists.txt
+++ b/wrap/submodules/dynamics/CMakeLists.txt
@@ -31,3 +31,7 @@ set(all_modules_python_sources
   ${all_modules_python_sources}
   ${current_sources_}
   PARENT_SCOPE)
+
+install(FILES ${wrap_header_${module_name_}}
+  DESTINATION ${CMAKE_INSTALL_PYTHONINCLUDEDIR}/${module_name_}/
+  COMPONENT development)

--- a/wrap/submodules/locate/CMakeLists.txt
+++ b/wrap/submodules/locate/CMakeLists.txt
@@ -14,3 +14,7 @@ set(all_modules_python_sources
   ${all_modules_python_sources}
   ${current_sources_}
   PARENT_SCOPE)
+
+install(FILES ${wrap_header_${module_name_}}
+  DESTINATION ${CMAKE_INSTALL_PYTHONINCLUDEDIR}/${module_name_}/
+  COMPONENT development)


### PR DESCRIPTION
- Export _sgext (python) to be reused by external modules with SGEXT from a build tree.
- In build and install trees external modules are able tore-use CMake files
  from SGEXT.

Test it in the existing test/mock_project.