### PR TITLE
Feature: Add morphological_watershed

### DIFF
--- a/modules/scripts/CMakeLists.txt
+++ b/modules/scripts/CMakeLists.txt
@@ -51,6 +51,7 @@ set(SG_MODULE_${SG_MODULE_NAME}_SOURCES
   thin_function.cpp
   reconstruct_from_distance_map.cpp
   voxelize_graph.cpp
+  morphological_watershed.cpp
   )
 
 list(TRANSFORM SG_MODULE_${SG_MODULE_NAME}_SOURCES PREPEND "src/")

--- a/modules/scripts/include/morphological_watershed.hpp
+++ b/modules/scripts/include/morphological_watershed.hpp
@@ -1,0 +1,29 @@
+/* Copyright (C) 2020 Pablo Hernandez-Cerdan
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef SG_MORPHOLOGICAL_WATERSHED_HPP
+#define SG_MORPHOLOGICAL_WATERSHED_HPP
+
+#include "scripts_types.hpp"
+
+namespace SG {
+
+/**
+ * Performs a morphological watershed from markers to "refill" the original
+ * binary image from a marker image that can have different labels,
+ * marker_image is usually set to the output image of @ref voxelize_graph.
+ *
+ * @param original_binary_image original binary image
+ * @param marker_image image with markers from for example @ref voxelize_graph
+ *
+ * @return original_binary_image but with labels propagated from the marker
+ * image.
+ */
+BinaryImageType::Pointer
+morphological_watershed(const BinaryImageType::Pointer &original_binary_image,
+                        const BinaryImageType::Pointer &marker_image);
+
+} // end namespace SG
+#endif

--- a/modules/scripts/src/morphological_watershed.cpp
+++ b/modules/scripts/src/morphological_watershed.cpp
@@ -1,0 +1,49 @@
+/* Copyright (C) 2020 Pablo Hernandez-Cerdan
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "morphological_watershed.hpp"
+#include <itkInvertIntensityImageFilter.h>
+#include <itkMaskImageFilter.h>
+#include <itkMorphologicalWatershedFromMarkersImageFilter.h>
+
+namespace SG {
+
+BinaryImageType::Pointer
+morphological_watershed(const BinaryImageType::Pointer &original_binary_image,
+                        const BinaryImageType::Pointer &label_marker_image) {
+
+    // Use the the inverted binary original binary image instead of a gradient
+    // for setting the watershed contour.
+    using InverterType =
+            itk::InvertIntensityImageFilter<BinaryImageType, BinaryImageType>;
+    auto inverter = InverterType::New();
+    inverter->SetInput(original_binary_image);
+    inverter->Update();
+
+    using WatershedFilterType =
+            itk::MorphologicalWatershedFromMarkersImageFilter<BinaryImageType,
+                                                              BinaryImageType>;
+    auto watershed_filter = WatershedFilterType::New();
+    watershed_filter->SetInput1(inverter->GetOutput());
+    watershed_filter->SetMarkerImage(label_marker_image);
+    // If On, voxels values between labels would be zero, creating disconnected
+    // components.
+    watershed_filter->MarkWatershedLineOff();
+    // Fully connected always on for label images.
+    watershed_filter->FullyConnectedOn();
+
+    // Mask the watershed image with the original_binary_image
+    // because watershed always bleeds out.
+    using MaskFilterType =
+            itk::MaskImageFilter<BinaryImageType, BinaryImageType>;
+    auto mask_filter = MaskFilterType::New();
+    mask_filter->SetInput(watershed_filter->GetOutput());
+    mask_filter->SetMaskImage(original_binary_image);
+    mask_filter->Update();
+
+    return mask_filter->GetOutput();
+}
+
+} // end namespace SG

--- a/wrap/submodules/scripts/CMakeLists.txt
+++ b/wrap/submodules/scripts/CMakeLists.txt
@@ -9,6 +9,7 @@ set(current_sources_
   resample_image_py.cpp
   reconstruct_from_distance_map_py.cpp
   voxelize_graph_py.cpp
+  morphological_watershed_py.cpp
   )
 
 if(SG_MODULE_ANALYZE)

--- a/wrap/submodules/scripts/morphological_watershed_py.cpp
+++ b/wrap/submodules/scripts/morphological_watershed_py.cpp
@@ -1,0 +1,33 @@
+/* Copyright (C) 2019 Pablo Hernandez-Cerdan
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "pybind11_common.h"
+
+#include "morphological_watershed.hpp"
+
+namespace py = pybind11;
+using namespace SG;
+
+void init_morphological_watershed(py::module &m) {
+    m.def("morphological_watershed", &morphological_watershed,
+            R"(Performs a morphological watershed from markers to "refill" the original
+binary image from a marker image that can have different labels,
+marker_image is usually set to the output image of sgext.scripts.voxelize_graph.
+
+Parameters:
+----------
+
+original_binary_image: BinaryImageType
+  input original image that will set the boundaries to refill from markers
+
+label_marker_image: BinaryImageType
+  image with markers from for example sgext.scripts.voxelize_graph
+
+Returns: BinaryImageType
+  original_binary_image but with labels propagated from the marker image.)",
+            py::arg("original_binary_image"),
+            py::arg("label_marker_image")
+            );
+}

--- a/wrap/submodules/scripts/sgscripts_init_py.cpp
+++ b/wrap/submodules/scripts/sgscripts_init_py.cpp
@@ -13,6 +13,7 @@ void init_mask_image(py::module &);
 void init_fill_holes(py::module &);
 void init_resample_image(py::module &);
 void init_voxelize_graph(py::module &);
+void init_morphological_watershed(py::module &);
 #ifdef SG_MODULE_VISUALIZE_ENABLED
 void init_visualize_spatial_graph(py::module &);
 void init_reconstruct_from_distance_map(py::module &);
@@ -28,6 +29,7 @@ void init_sgscripts(py::module & mparent) {
     init_fill_holes(m);
     init_resample_image(m);
     init_voxelize_graph(m);
+    init_morphological_watershed(m);
 #ifdef SG_MODULE_VISUALIZE_ENABLED
     init_visualize_spatial_graph(m);
     init_reconstruct_from_distance_map(m);


### PR DESCRIPTION
Using the label image resulting from voxelize_graph
and the original segmentation, we can restore the original segmentation
but with the labels from the graph.

Using itk::MorphologicalWatershedFromMarkersImageFilter