### PR TITLE
Azure: Fix azure macos

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,9 +48,17 @@ stages:
         runVersion: 'latest'
         artifact: DEPENDENCIES_BUILD_DIR_MACOS
         path: $(DEPENDENCIES_BUILD_DIR)
+
+    - script: sudo xcode-select -switch /Applications/Xcode_12.3.app
+      displayName: "Select Xcode version"
+
+    - script: xcodebuild -version
+      displayName: "Xcode version"
+
     - task: UsePythonVersion@0
       inputs:
         versionSpec: '$(python.version)'
+
     - task: Bash@3
       inputs:
         filePath: '$(Build.SourcesDirectory)/deploy/deploy_macos_one_python.sh'

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -224,6 +224,9 @@ if ( APPLE )
       cxxflags=-std=c++${CMAKE_CXX_STANDARD}
       cxxflags=-stdlib=libc++
       cxxflags=-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}
+      # Solves: ld: warning: direct access in function ... from file ... to global weak symbol
+      # Needed because we are building with link=static
+      cxxflags=-fvisibility=hidden
       linkflags=-stdlib=libc++
       )
   endif()

--- a/dependencies/azure-pipelines.yml
+++ b/dependencies/azure-pipelines.yml
@@ -37,6 +37,12 @@ stages:
     displayName: 'BuildDependencies'
     timeoutInMinutes: 0
     steps:
+    - script: sudo xcode-select -switch /Applications/Xcode_12.3.app
+      displayName: "Select Xcode version"
+
+    - script: xcodebuild -version
+      displayName: "Xcode version"
+
     - script: |
         mkdir $DEPENDENCIES_BUILD_DIR
         echo $DEPENDENCIES_BUILD_DIR

--- a/modules/dynamics/include/unbonded_forces.hpp
+++ b/modules/dynamics/include/unbonded_forces.hpp
@@ -22,7 +22,7 @@
 #define SG_UNBONDED_FORCES_HPP
 
 #include "array_utilities.hpp"
-#include <math.h>
+#include <cmath>
 
 namespace SG {
 

--- a/modules/generate/include/cumulative_distribution_functions.hpp
+++ b/modules/generate/include/cumulative_distribution_functions.hpp
@@ -24,7 +24,7 @@
 #include <algorithm>
 #include <boost/math/constants/constants.hpp> // for pi...
 #include <functional>                         // std::function
-#include <math.h>                             // erf
+#include <cmath>                              // erf
 
 #ifdef WITH_PARALLEL_STL
 #include <execution>                          // std::execution::par_unseq


### PR DESCRIPTION
Azure: Fix azure macos

```
/Applications/Xcode_12.3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:319:9: error: no member named 'isfinite' in the global namespace; did you mean 'finite'?
using ::isfinite;
      ~~^
/Applications/Xcode_12.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk/usr/include/math.h:752:12: note: 'finite' declared here
extern int finite(double)
```

Proposed fix: use `#include <cmath>` before any `#include "math.h"`
From: https://developer.apple.com/forums/thread/110594

Note: It's disturbing the reference to Xcode_12.2 when Xcode_12.3 seems
the default (or vice versa).
Azure defaults: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode

To fix the later, explicitly select the xcode with:
 `xcode-select -switch /applications/Xcode_12.3.app`


The second commit tries to fix warnings in macos about visibility (partially successful)
