### PR TITLE
Fix histo warnings msvc

### DIFF
--- a/external/histo/include/histo.hpp
+++ b/external/histo/include/histo.hpp
@@ -70,10 +70,10 @@ enum breaks_method {
  */
 template <typename PRECI = double>
 std::vector<PRECI> GenerateBreaksFromRangeAndBins(
-        const PRECI &low, const PRECI &upper, const unsigned long int &bins) {
+        const PRECI &low, const PRECI &upper, const size_t &bins) {
     std::vector<PRECI> breaks(bins + 1);
     PRECI width = (upper - low) / static_cast<PRECI>(bins);
-    for (unsigned long int i = 0; i != bins + 1; i++) {
+    for (size_t i = 0; i != bins + 1; i++) {
         breaks[i] = low + i * width;
     }
     return breaks;
@@ -82,7 +82,7 @@ std::vector<PRECI> GenerateBreaksFromRangeAndBins(
 template <typename PRECI = double>
 std::vector<PRECI>
 GenerateBreaksFromRangeAndBins(const std::pair<PRECI, PRECI> &range_low_upper,
-                               const unsigned long int &bins) {
+                               const size_t &bins) {
     auto low = range_low_upper.first;
     auto upper = range_low_upper.second;
     return GenerateBreaksFromRangeAndBins<PRECI>(low, upper, bins);
@@ -173,7 +173,7 @@ bool isequalthan(const TData &v1, const TData &v2) {
  * @tparam PRECI It should be equal to T, except when T is int.
  * @tparam PRECI_INTEGER int type for counts data member.
  */
-template <typename PRECI = double, typename PRECI_INTEGER = unsigned long int>
+template <typename PRECI = double, typename PRECI_INTEGER = size_t>
 struct Histo {
     using BreaksType = std::vector<PRECI>;
     using RangeType = std::pair<PRECI, PRECI>;
@@ -185,7 +185,7 @@ struct Histo {
      *  size.breaks = size.counts + 1. */
     BreaksType breaks;
     /** breaks.size() - 1 */
-    unsigned long int bins{0};
+    size_t bins{0};
     /** int vector holding the counts for each breaks interval.*/
     CountsType counts;
     /** name/description of the histogram */
@@ -333,12 +333,11 @@ struct Histo {
      * @return Index of counts
      */
     template <typename TData>
-    unsigned long int IndexFromValue(const TData &value) const {
+    size_t IndexFromValue(const TData &value) const {
         // We could use this with a custom comparator:
         // typename std::vector<T>::iterator low =
         // std::lower_bound(breaks.begin(), breaks.end(), value);
-        unsigned long int lo{0}, hi{bins},
-                newb; // include right border in the last bin.
+        size_t lo{0}, hi{bins}, newb; // include right border in the last bin.
         if (value >= breaks[lo] &&
             (value < breaks[hi] ||
              histo::isequalthan<PRECI>(value, breaks[hi]))) {
@@ -387,7 +386,7 @@ struct Histo {
      *
      * @param index of counts
      */
-    void Increase(const unsigned long int &index) {
+    void Increase(const size_t &index) {
         if (counts[index] == std::numeric_limits<PRECI_INTEGER>::max())
             throw histo_error("Increase has exceded PRECI_INTEGER."
                               " Index: " +
@@ -399,7 +398,7 @@ struct Histo {
     /** @brief Decrease count by one, checking if it goes negative.
      * @param index of counts.
      */
-    void Decrease(const unsigned long int &index) {
+    void Decrease(const size_t &index) {
         if (counts[index] <= 0)
             throw histo_error("Decrease has reached negative value."
                               " Index: " +
@@ -412,7 +411,7 @@ struct Histo {
      * @param index of counts.
      * @param v value to set.
      */
-    void SetCount(const unsigned long int &index, const PRECI_INTEGER &v) {
+    void SetCount(const size_t &index, const PRECI_INTEGER &v) {
         if (index > bins)
             throw histo_error("Index is out of bounds in SetCount"
                               " Index: " +
@@ -480,7 +479,7 @@ struct Histo {
                               "Equidistant breaks");
         }
 
-        unsigned long int nbins = input_breaks.size() - 1;
+        size_t nbins = input_breaks.size() - 1;
         PRECI width = input_breaks[1] - input_breaks[0];
         // diff_low is > 0 when it does not reach range, and < 0 when it goes
         // beyond.
@@ -550,7 +549,7 @@ struct Histo {
     };
     void ShrinkOrExpandBreaks(BreaksType &input_breaks,
                               const PRECI &d) const {
-        unsigned long int i{0};
+        size_t i{0};
         for (auto &v : input_breaks) {
             v = v + i * d;
             i++;
@@ -572,9 +571,10 @@ struct Histo {
         // cbrt is cubic root
         PRECI width =
                 3.5 * sqrt(sigma) / std::cbrt(static_cast<PRECI>(data.size()));
-        this->bins = std::ceil((rang.second - rang.first) / width);
+        this->bins = static_cast<size_t>(
+            std::ceil((rang.second - rang.first) / width));
         this->breaks.resize(bins + 1);
-        for (unsigned long int i = 0; i != bins + 1; i++) {
+        for (size_t i = 0; i != bins + 1; i++) {
             this->breaks[i] = this->range.first + i * width;
         }
         // std::cout << "Non balanced breaks" << std::endl;
@@ -597,7 +597,7 @@ struct Histo {
     };
 };
 
-template <typename PRECI = double, typename PRECI_INTEGER = unsigned long int>
+template <typename PRECI = double, typename PRECI_INTEGER = size_t>
 double
 Mean(const Histo<PRECI, PRECI_INTEGER> &input_histo) {
   const auto bin_centers = input_histo.ComputeBinCenters();
@@ -622,7 +622,7 @@ Mean(const Histo<PRECI, PRECI_INTEGER> &input_histo) {
  *
  * @return histogram normalized with float counts.
  */
-template <typename PRECI = double, typename PRECI_INTEGER = unsigned long int>
+template <typename PRECI = double, typename PRECI_INTEGER = size_t>
 Histo<PRECI, PRECI>
 NormalizeByArea(const Histo<PRECI, PRECI_INTEGER> &input_histo) {
     // compute the area of each bin

--- a/modules/analyze/src/compute_graph_properties.cpp
+++ b/modules/analyze/src/compute_graph_properties.cpp
@@ -27,7 +27,7 @@ std::vector<unsigned int> compute_degrees(const SG::GraphType &sg) {
     std::vector<unsigned int> degrees;
     const auto verts = boost::vertices(sg);
     for (auto vi = verts.first; vi != verts.second; ++vi) {
-        degrees.push_back(boost::degree(*vi, sg));
+        degrees.push_back(static_cast<unsigned int>(boost::degree(*vi, sg)));
     }
     return degrees;
 }

--- a/modules/analyze/src/spatial_histograms.cpp
+++ b/modules/analyze/src/spatial_histograms.cpp
@@ -35,7 +35,8 @@ histo::Histo<double> read_histogram(std::istream &is) {
     histo::Histo<double> histo;
     std::string line;
     std::istringstream ss;
-    double num;
+    double input_break;
+    size_t input_count;
     // Header, ignore
     std::getline(is, line);
     std::string delim_first = "# ";
@@ -51,15 +52,15 @@ histo::Histo<double> read_histogram(std::istream &is) {
     std::getline(is, line);
     ss.clear();
     ss.str(line);
-    while (ss >> num) {
-        histo.counts.push_back(num);
+    while (ss >> input_count) {
+        histo.counts.push_back(input_count);
     }
     // Breaks, store
     std::getline(is, line);
     ss.clear();
     ss.str(line);
-    while (ss >> num) {
-        histo.breaks.push_back(num);
+    while (ss >> input_break) {
+        histo.breaks.push_back(input_break);
     }
 
     // Complete histogram:

--- a/modules/generate/src/degree_viger_generator.cpp
+++ b/modules/generate/src/degree_viger_generator.cpp
@@ -157,7 +157,7 @@ int degree_viger_generator::max_degree() const {
 }
 
 void degree_viger_generator::alloc(const std::vector<int> &degree_sequence) {
-    num_vertices_ = std::size(degree_sequence);
+    num_vertices_ = static_cast<int>(std::size(degree_sequence));
     arcs_ = std::accumulate(std::begin(degree_sequence),
                             std::end(degree_sequence), 0);
     assert(arcs_ % 2 == 0); // arcs must be even

--- a/modules/generate/src/simulated_annealing_generator.cpp
+++ b/modules/generate/src/simulated_annealing_generator.cpp
@@ -206,7 +206,8 @@ void simulated_annealing_generator::populate_histogram_ete_distances() {
     LUT.resize(histo_ete_distances_.bins);
     const auto total_counts =
             std::accumulate(std::begin(histo_ete_distances_.counts),
-                            std::end(histo_ete_distances_.counts), 0LU);
+                            std::end(histo_ete_distances_.counts),
+                            static_cast<size_t>(0));
     std::transform(std::begin(target_cumulative_distro_histo_ete_distances_),
                    std::end(target_cumulative_distro_histo_ete_distances_),
                    std::begin(LUT),
@@ -225,7 +226,8 @@ void simulated_annealing_generator::populate_histogram_cosines() {
     LUT.resize(histo_cosines_.bins);
     const auto total_counts =
             std::accumulate(std::begin(histo_cosines_.counts),
-                            std::end(histo_cosines_.counts), 0LU);
+                            std::end(histo_cosines_.counts),
+                            static_cast<size_t>(0));
     std::transform(std::begin(target_cumulative_distro_histo_cosines_),
                    std::end(target_cumulative_distro_histo_cosines_),
                    std::begin(LUT),
@@ -269,7 +271,9 @@ void simulated_annealing_generator::engine(const bool &reset_steps) {
     /****** For reporting progress **********/
     const double log_size =
             std::log10(transition_params.MAX_ENGINE_ITERATIONS) - 2;
-    const size_t report_every = log_size > 0 ? std::pow(10, log_size) : 1;
+    const size_t report_every = log_size > 0 ?
+        static_cast<size_t>(std::pow(10, log_size)) :
+        1;
     size_t progress_count = 0;
     /****/
     const double energy_initial = compute_energy();
@@ -510,7 +514,8 @@ void simulated_annealing_generator::
     const auto &distro = target_cumulative_distro_histo_ete_distances_;
     auto target_bins = distro;
     const size_t N = std::accumulate(std::begin(histo.counts),
-                                     std::end(histo.counts), 0.0);
+                                     std::end(histo.counts),
+                                     static_cast<size_t>(0));
     for (size_t i = 0; i < std::size(distro); i++) {
         const auto t = distro[i];
         const double diff = (i == 0) ? t : t - distro[i - 1];
@@ -525,7 +530,8 @@ void simulated_annealing_generator::print_histo_and_target_distribution_cosines(
     const auto &distro = target_cumulative_distro_histo_cosines_;
     auto target_bins = distro;
     const size_t N = std::accumulate(std::begin(histo.counts),
-                                     std::end(histo.counts), 0.0);
+                                     std::end(histo.counts),
+                                     static_cast<size_t>(0));
     for (size_t i = 0; i < std::size(distro); i++) {
         const auto t = distro[i];
         const double diff = (i == 0) ? t : t - distro[i - 1];

--- a/wrap/submodules/generate/histo/histo_init_py.cpp
+++ b/wrap/submodules/generate/histo/histo_init_py.cpp
@@ -34,11 +34,11 @@ void init_histo(py::module & mparent) {
 
     // Free functions
     m.def("generate_breaks_from_range_and_bins",
-            py::overload_cast<const double&, const double&, const unsigned long int&>(
+            py::overload_cast<const double&, const double&, const size_t&>(
             &histo::GenerateBreaksFromRangeAndBins<double>),
             py::arg("low"), py::arg("upper"), py::arg("bins"));
     m.def("generate_breaks_from_range_and_bins",
-            py::overload_cast<const std::pair<double, double> &, const unsigned long int&>(
+            py::overload_cast<const std::pair<double, double> &, const size_t&>(
             &histo::GenerateBreaksFromRangeAndBins<double>),
             py::arg("range"), py::arg("bins"));
     m.def("generate_breaks_from_range_and_width",


### PR DESCRIPTION
Fix narrowing conversion warnings generated in `histo.hpp` in windows.