### PR TITLE
Fix CMake function for testing in Windows (cpp and python)

### DIFF
--- a/cmake/SGEXT_SGModuleMacros.cmake
+++ b/cmake/SGEXT_SGModuleMacros.cmake
@@ -21,7 +21,7 @@ macro(SG_add_gtests)
       ${SG_MODULE_${SG_MODULE_NAME}_TEST_SYSTEM_INCLUDE_DIRS})
     gtest_discover_tests(
       ${test_name}
-      TEST_PREFIX ${SG_MODULE_NAME}||${test_name}||
+      TEST_PREFIX ${SG_MODULE_NAME}__${test_name}__
       PROPERTIES LABELS ${SG_MODULE_NAME}
       )
     if(${ARGC} GREATER 2)

--- a/cmake/SGEXT_SGModuleMacros.cmake
+++ b/cmake/SGEXT_SGModuleMacros.cmake
@@ -29,3 +29,35 @@ macro(SG_add_gtests)
     endif()
   endforeach()
 endmacro(SG_add_gtests)
+
+# Minimum requirement is a list of python_tests_:
+#  set(python_tests_
+#   test_array3d.py
+#   test_graph.py
+#  )
+# And the module_name_ and test_folder:
+#  get_filename_component(module_name_ ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+#  set(test_folder "${CMAKE_CURRENT_SOURCE_DIR}")
+macro(SG_add_python_tests)
+  # test files should start with "test_"
+  # unittest functions (in .py) should start with "test_" for discover to work
+  foreach(python_test ${python_tests})
+    set(python_test_name_ python||${module_name}||${python_test})
+    add_test(NAME ${python_test_name_}
+      COMMAND
+      ${PYTHON_EXECUTABLE}
+      -m unittest discover
+      -s ${test_folder}
+      -p ${python_test}
+      )
+    # Append the build folder where python lib is to PYTHONPATH
+    # Allowing ctest -R "a_python_test_name_" -V to work
+    if(WIN32)
+      set(_path_sep "\;")
+    else()
+      set(_path_sep ":")
+    endif()
+    set_tests_properties(${python_test_name_} PROPERTIES
+      ENVIRONMENT "PYTHONPATH=$ENV{PYTHONPATH}${_path_sep}${CMAKE_BUILD_PYTHONLIBDIR}/..")
+  endforeach()
+endmacro(SG_add_python_tests)

--- a/wrap/test/analyze/CMakeLists.txt
+++ b/wrap/test/analyze/CMakeLists.txt
@@ -1,22 +1,8 @@
-set(python_tests_
+set(python_tests
   test_compute_graph_properties.py
   )
 
-get_filename_component(module_name_ ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+get_filename_component(module_name ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 set(test_folder "${CMAKE_CURRENT_SOURCE_DIR}")
-# test files should start with "test_"
-# unittest functions (in .py) should start with "test_" for discover to work
-foreach(python_test ${python_tests_})
-  set(python_test_name_ python||${module_name_}||${python_test})
-  add_test(NAME ${python_test_name_}
-    COMMAND
-    ${PYTHON_EXECUTABLE}
-    -m unittest discover
-    -s ${test_folder}
-    -p ${python_test}
-    )
-  # Append the build folder where python lib is to PYTHONPATH
-  # Allowing ctest -R "a_python_test_name_" -V to work
-  set_tests_properties(${python_test_name_} PROPERTIES
-    ENVIRONMENT PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_BUILD_PYTHONLIBDIR}/..)
-endforeach()
+
+SG_add_python_tests()

--- a/wrap/test/compare/CMakeLists.txt
+++ b/wrap/test/compare/CMakeLists.txt
@@ -1,22 +1,8 @@
-set(python_tests_
+set(python_tests
   test_compare.py
   )
 
-get_filename_component(module_name_ ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+get_filename_component(module_name ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 set(test_folder "${CMAKE_CURRENT_SOURCE_DIR}")
-# test files should start with "test_"
-# unittest functions (in .py) should start with "test_" for discover to work
-foreach(python_test ${python_tests_})
-  set(python_test_name_ python||${module_name_}||${python_test})
-  add_test(NAME ${python_test_name_}
-    COMMAND
-    ${PYTHON_EXECUTABLE}
-    -m unittest discover
-    -s ${test_folder}
-    -p ${python_test}
-    )
-  # Append the build folder where python lib is to PYTHONPATH
-  # Allowing ctest -R "a_python_test_name_" -V to work
-  set_tests_properties(${python_test_name_} PROPERTIES
-    ENVIRONMENT PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_BUILD_PYTHONLIBDIR}/..)
-endforeach()
+
+SG_add_python_tests()

--- a/wrap/test/core/CMakeLists.txt
+++ b/wrap/test/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(python_tests_
+set(python_tests
   test_array3d.py
   test_edge_points_utilities.py
   test_graph.py
@@ -6,21 +6,7 @@ set(python_tests_
   test_bounding_box.py
   )
 
-get_filename_component(module_name_ ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+get_filename_component(module_name ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 set(test_folder "${CMAKE_CURRENT_SOURCE_DIR}")
-# test files should start with "test_"
-# unittest functions (in .py) should start with "test_" for discover to work
-foreach(python_test ${python_tests_})
-  set(python_test_name_ python||${module_name_}||${python_test})
-  add_test(NAME ${python_test_name_}
-    COMMAND
-    ${PYTHON_EXECUTABLE}
-    -m unittest discover
-    -s ${test_folder}
-    -p ${python_test}
-    )
-  # Append the build folder where python lib is to PYTHONPATH
-  # Allowing ctest -R "a_python_test_name_" -V to work
-  set_tests_properties(${python_test_name_} PROPERTIES
-    ENVIRONMENT PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_BUILD_PYTHONLIBDIR}/..)
-endforeach()
+
+SG_add_python_tests()

--- a/wrap/test/dynamics/CMakeLists.txt
+++ b/wrap/test/dynamics/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(python_tests_
+set(python_tests
   test_particle.py
   test_bond.py
   test_particle_collection.py
@@ -8,21 +8,7 @@ set(python_tests_
   test_integrator.py
   )
 
-get_filename_component(module_name_ ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+get_filename_component(module_name ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 set(test_folder "${CMAKE_CURRENT_SOURCE_DIR}")
-# test files should start with "test_"
-# unittest functions (in .py) should start with "test_" for discover to work
-foreach(python_test ${python_tests_})
-  set(python_test_name_ python||${module_name_}||${python_test})
-  add_test(NAME ${python_test_name_}
-    COMMAND
-    ${PYTHON_EXECUTABLE}
-    -m unittest discover
-    -s ${test_folder}
-    -p ${python_test}
-    )
-  # Append the build folder where python lib is to PYTHONPATH
-  # Allowing ctest -R "a_python_test_name_" -V to work
-  set_tests_properties(${python_test_name_} PROPERTIES
-    ENVIRONMENT PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_BUILD_PYTHONLIBDIR}/..)
-endforeach()
+
+SG_add_python_tests()

--- a/wrap/test/extract/CMakeLists.txt
+++ b/wrap/test/extract/CMakeLists.txt
@@ -1,22 +1,8 @@
-set(python_tests_
+set(python_tests
   test_extract.py
   )
 
-get_filename_component(module_name_ ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+get_filename_component(module_name ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 set(test_folder "${CMAKE_CURRENT_SOURCE_DIR}")
-# test files should start with "test_"
-# unittest functions (in .py) should start with "test_" for discover to work
-foreach(python_test ${python_tests_})
-  set(python_test_name_ python||${module_name_}||${python_test})
-  add_test(NAME ${python_test_name_}
-    COMMAND
-    ${PYTHON_EXECUTABLE}
-    -m unittest discover
-    -s ${test_folder}
-    -p ${python_test}
-    )
-  # Append the build folder where python lib is to PYTHONPATH
-  # Allowing ctest -R "a_python_test_name_" -V to work
-  set_tests_properties(${python_test_name_} PROPERTIES
-    ENVIRONMENT PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_BUILD_PYTHONLIBDIR}/..)
-endforeach()
+
+SG_add_python_tests()

--- a/wrap/test/generate/CMakeLists.txt
+++ b/wrap/test/generate/CMakeLists.txt
@@ -1,23 +1,9 @@
-set(python_tests_
+set(python_tests
   test_simulated_annealing_generator.py
   )
-get_filename_component(module_name_ ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+get_filename_component(module_name ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 set(test_folder "${CMAKE_CURRENT_SOURCE_DIR}")
-# test files should start with "test_"
-# unittest functions (in .py) should start with "test_" for discover to work
-foreach(python_test ${python_tests_})
-  set(python_test_name_ python||${module_name_}||${python_test})
-  add_test(NAME ${python_test_name_}
-    COMMAND
-    ${PYTHON_EXECUTABLE}
-    -m unittest discover
-    -s ${test_folder}
-    -p ${python_test}
-    )
-  # Append the build folder where python lib is to PYTHONPATH
-  # Allowing ctest -R "a_python_test_name_" -V to work
-  set_tests_properties(${python_test_name_} PROPERTIES
-    ENVIRONMENT PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_BUILD_PYTHONLIBDIR}/..)
-endforeach()
+
+SG_add_python_tests()
 
 add_subdirectory(histo)

--- a/wrap/test/generate/histo/CMakeLists.txt
+++ b/wrap/test/generate/histo/CMakeLists.txt
@@ -1,21 +1,7 @@
-set(python_tests_
+set(python_tests
   test_histo.py
   )
-get_filename_component(module_name_ ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+get_filename_component(module_name ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 set(test_folder "${CMAKE_CURRENT_SOURCE_DIR}")
-# test files should start with "test_"
-# unittest functions (in .py) should start with "test_" for discover to work
-foreach(python_test ${python_tests_})
-  set(python_test_name_ python||${module_name_}||${python_test})
-  add_test(NAME ${python_test_name_}
-    COMMAND
-    ${PYTHON_EXECUTABLE}
-    -m unittest discover
-    -s ${test_folder}
-    -p ${python_test}
-    )
-  # Append the build folder where python lib is to PYTHONPATH
-  # Allowing ctest -R "a_python_test_name_" -V to work
-  set_tests_properties(${python_test_name_} PROPERTIES
-    ENVIRONMENT PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_BUILD_PYTHONLIBDIR}/..)
-endforeach()
+
+SG_add_python_tests()

--- a/wrap/test/itk/CMakeLists.txt
+++ b/wrap/test/itk/CMakeLists.txt
@@ -1,28 +1,14 @@
 if(SG_BUILD_TESTING_INTERACTIVE)
   set(_with_interactive_tests test_itk_view_image.py)
 endif()
-set(python_tests_
+set(python_tests
   test_itk_image.py
   test_itk_image_io.py
   test_from_to_itk.py
   ${_with_interactive_tests}
   )
 
-get_filename_component(module_name_ ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+get_filename_component(module_name ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 set(test_folder "${CMAKE_CURRENT_SOURCE_DIR}")
-# test files should start with "test_"
-# unittest functions (in .py) should start with "test_" for discover to work
-foreach(python_test ${python_tests_})
-  set(python_test_name_ python||${module_name_}||${python_test})
-  add_test(NAME ${python_test_name_}
-    COMMAND
-    ${PYTHON_EXECUTABLE}
-    -m unittest discover
-    -s ${test_folder}
-    -p ${python_test}
-    )
-  # Append the build folder where sgext python folder is to PYTHONPATH
-  # Allowing ctest -R "a_python_test_name_" -V to work
-  set_tests_properties(${python_test_name_} PROPERTIES
-    ENVIRONMENT PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_BUILD_PYTHONLIBDIR}/..)
-endforeach()
+
+SG_add_python_tests()

--- a/wrap/test/locate/CMakeLists.txt
+++ b/wrap/test/locate/CMakeLists.txt
@@ -1,21 +1,7 @@
-set(python_tests_
+set(python_tests
   test_locate.py
   )
-get_filename_component(module_name_ ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+get_filename_component(module_name ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 set(test_folder "${CMAKE_CURRENT_SOURCE_DIR}")
-# test files should start with "test_"
-# unittest functions (in .py) should start with "test_" for discover to work
-foreach(python_test ${python_tests_})
-  set(python_test_name_ python||${module_name_}||${python_test})
-  add_test(NAME ${python_test_name_}
-    COMMAND
-    ${PYTHON_EXECUTABLE}
-    -m unittest discover
-    -s ${test_folder}
-    -p ${python_test}
-    )
-  # Append the build folder where python lib is to PYTHONPATH
-  # Allowing ctest -R "a_python_test_name_" -V to work
-  set_tests_properties(${python_test_name_} PROPERTIES
-    ENVIRONMENT PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_BUILD_PYTHONLIBDIR}/..)
-endforeach()
+
+SG_add_python_tests()

--- a/wrap/test/scripts/CMakeLists.txt
+++ b/wrap/test/scripts/CMakeLists.txt
@@ -1,25 +1,11 @@
-set(python_tests_
+set(python_tests
   test_thin.py
   test_create_distance_map.py
   test_resample.py
   test_voxelize_graph.py
   )
 
-get_filename_component(module_name_ ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+get_filename_component(module_name ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 set(test_folder "${CMAKE_CURRENT_SOURCE_DIR}")
-# test files should start with "test_"
-# unittest functions (in .py) should start with "test_" for discover to work
-foreach(python_test ${python_tests_})
-  set(python_test_name_ python||${module_name_}||${python_test})
-  add_test(NAME ${python_test_name_}
-    COMMAND
-    ${PYTHON_EXECUTABLE}
-    -m unittest discover
-    -s ${test_folder}
-    -p ${python_test}
-    )
-  # Append the build folder where python lib is to PYTHONPATH
-  # Allowing ctest -R "a_python_test_name_" -V to work
-  set_tests_properties(${python_test_name_} PROPERTIES
-    ENVIRONMENT PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_BUILD_PYTHONLIBDIR}/..)
-endforeach()
+
+SG_add_python_tests()

--- a/wrap/test/visualize/CMakeLists.txt
+++ b/wrap/test/visualize/CMakeLists.txt
@@ -1,21 +1,7 @@
-set(python_tests_
+set(python_tests
   test_visualize.py
   )
-get_filename_component(module_name_ ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+get_filename_component(module_name ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 set(test_folder "${CMAKE_CURRENT_SOURCE_DIR}")
-# test files should start with "test_"
-# unittest functions (in .py) should start with "test_" for discover to work
-foreach(python_test ${python_tests_})
-  set(python_test_name_ python||${module_name_}||${python_test})
-  add_test(NAME ${python_test_name_}
-    COMMAND
-    ${PYTHON_EXECUTABLE}
-    -m unittest discover
-    -s ${test_folder}
-    -p ${python_test}
-    )
-  # Append the build folder where python lib is to PYTHONPATH
-  # Allowing ctest -R "a_python_test_name_" -V to work
-  set_tests_properties(${python_test_name_} PROPERTIES
-    ENVIRONMENT PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_BUILD_PYTHONLIBDIR}/..)
-endforeach()
+
+SG_add_python_tests()


### PR DESCRIPTION
Fix macro SG_add_gtests (in TEST_PREFIX replace `||` for `__`

Fix setting PYTHONPATH environment variable in windows. Now it uses the right separator `;` for windows.
For python, add a CMake macro `SG_add_python_tests` 