### PR TITLE
Add find_dependency(TBB) to SGEXTConfig

### DIFF
--- a/cmake/SGEXTConfig.cmake.in
+++ b/cmake/SGEXTConfig.cmake.in
@@ -25,6 +25,12 @@ if(@SG_REQUIRES_VTK@) # if(${SG_REQUIRES_VTK})
     REQUIRED
     )
 endif()
+# TBB is optionally used in modules/generate, only for GNU
+if(@SG_REQUIRES_TBB@) # if(${SG_REQUIRES_TBB})
+  set(OLD_CMAKE_FIND_PACKAGE_PREFER_CONFIG ${CMAKE_FIND_PACKAGE_PREFER_CONFIG})
+  find_dependency(TBB)
+  set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ${OLD_CMAKE_FIND_PACKAGE_PREFER_CONFIG})
+endif()
 
 get_filename_component(SGEXT_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 if(NOT TARGET SGCore)

--- a/modules/generate/CMakeLists.txt
+++ b/modules/generate/CMakeLists.txt
@@ -121,6 +121,7 @@ set(SG_MODULE_INTERNAL_DEPENDS
   )
 set(_optional_depends "")
 if(_has_parallel_stl AND _compiler_is_gnu)
+  set(SG_REQUIRES_TBB TRUE PARENT_SCOPE)
   list(APPEND _optional_depends ${_parallel_stl_extra_libraries})
 endif()
 set(SG_MODULE_${SG_MODULE_NAME}_DEPENDS


### PR DESCRIPTION
Only when required:
- SG_REQUIRES_TBB might be set in module generate (to parent scope)
- Only happens with GNU and modern compiler (_has_parallel_stl)