### PR TITLE
String change in thin_function.hpp

### DIFF
--- a/modules/scripts/include/thin_function.hpp
+++ b/modules/scripts/include/thin_function.hpp
@@ -49,7 +49,7 @@ inline std::string to_string(const SkelType & skel_en) {
     switch(skel_en)
     {
         case SkelType::end: return "end"; break;
-        case SkelType::ultimate: return "ultimate"; break;
+        case SkelType::ultimate: return "ulti"; break;
         case SkelType::isthmus1: return "isthmus1"; break;
         case SkelType::isthmus: return "isthmus"; break;
         default:
@@ -58,7 +58,7 @@ inline std::string to_string(const SkelType & skel_en) {
 }
 inline SkelType skel_string_to_enum(const std::string & skel_string) {
     if(skel_string == "end") return SkelType::end;
-    if(skel_string == "ultimate") return SkelType::ultimate;
+    if(skel_string == "ulti") return SkelType::ultimate;
     if(skel_string == "isthmus1") return SkelType::isthmus1;
     if(skel_string == "isthmus") return SkelType::isthmus;
     // for compatibility with thin_script: 1isthmus


### PR DESCRIPTION
Changed the string 'ultimate' to 'ulti', as that is the value defined in cpp-scripts/thin.cpp. Without this fix, the argument -s ulti for the thin function results in the error skel_string is not valid: "ulti" (see line 66 in modules/scripts/include/thin_function.hpp) while the use of -s ultimate is made impossible by the check in line 116 in cpp-scripts/thin.cpp. The ultimate option is therefore unreachable without this fix.